### PR TITLE
Fix camera problem

### DIFF
--- a/Chapter 1 Example Code/Twinstick Shooter/Assets/Scripts/PlayerBehaviour.cs
+++ b/Chapter 1 Example Code/Twinstick Shooter/Assets/Scripts/PlayerBehaviour.cs
@@ -96,6 +96,7 @@ public class PlayerBehaviour : MonoBehaviour {
 		// We need to tell where the mouse is relative to the 
 		// player
 		Vector3 worldPos = Input.mousePosition;
+        worldPos.z = 10;
 		worldPos = Camera.main.ScreenToWorldPoint(worldPos);
 		
 		/*


### PR DESCRIPTION
By setting the worldPos.z to 10, the camera functions properly and the
player is able to move around correctly.
